### PR TITLE
Don't log every request to the console

### DIFF
--- a/lib/pocket_api.rb
+++ b/lib/pocket_api.rb
@@ -79,7 +79,6 @@ module PocketApi
       arguments[1] ||= {}
       arguments[1][:body] ||= {}
       arguments[1][:body] = MultiJson.dump(arguments[1][:body].merge({:consumer_key => @client_key, :access_token => @access_token}))
-      puts arguments.inspect
       Connection.__send__(method.downcase.to_sym, *arguments)
     end
     


### PR DESCRIPTION
This was necessary as it was logging all the request arguments, which can be sensitive in nature (I wouldn't want my CONSUMER_KEY to be logged in my server logs.
